### PR TITLE
Dev hold&tap

### DIFF
--- a/qmk_firmware/keyboards/keyball/keyball44/keymaps/my_keymap/config.h
+++ b/qmk_firmware/keyboards/keyball/keyball44/keymaps/my_keymap/config.h
@@ -38,3 +38,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define POINTING_DEVICE_AUTO_MOUSE_ENABLE
 #define AUTO_MOUSE_DEFAULT_LAYER 1
 #define AUTO_MOUSE_LAYER_KEEP_TIME 30000
+
+#define PERMISSIVE_HOLD
+#define RETRO_TAPPING

--- a/qmk_firmware/keyboards/keyball/keyball44/keymaps/my_keymap/config.h
+++ b/qmk_firmware/keyboards/keyball/keyball44/keymaps/my_keymap/config.h
@@ -40,4 +40,4 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define AUTO_MOUSE_LAYER_KEEP_TIME 30000
 
 #define PERMISSIVE_HOLD
-#define RETRO_TAPPING
+#define TAPPING_TERM 300


### PR DESCRIPTION
・PERMISSIVE_HOLDを設定
ホールドキー押下中に別キーを押した場合、押下時間に関係なくホールド判定にする。
・TAPPING_TERMを300に設定
PERMISSIVE_HOLDを設定しているのでTAPPING_TERMを長めの300に変更。

[参考]
・https://x.com/keyashantung/status/1826274837779894749
・https://golden-lucky.hatenablog.com/entry/2021/03/06/182958#PERMISSIVE_HOLD%E3%81%AF%E6%A1%88%E5%A4%96%E3%81%A8%E4%BD%BF%E3%81%88%E3%81%AA%E3%81%84

