### PR TITLE
QUICK_TAP設定をオフに変更

### DIFF
--- a/BuildMemo.md
+++ b/BuildMemo.md
@@ -9,28 +9,31 @@
 $ git clone https://github.com/suijinn/keyball.git keyball
 
 
-2. qmk_firmwareのリポジトリクローン
+1. qmk_firmwareのリポジトリクローン
    対応しているバージョンに注意
 $ git clone https://github.com/qmk/qmk_firmware.git --depth 1 --recurse-submodules --shallow-submodules -b 0.22.14 qmk
 
-3. keyball→qmkへのシンボリックリンクを貼る
+1. keyball→qmkへのシンボリックリンクを貼る
 mklink /D %USERPROFILE%\qmk\keyboards\keyball %USERPROFILE%\keyball\qmk_firmware\keyboards\keyball
 
-4. 編集する。keymapはkeyball44/my_keymap/以下を使う。
+1. 編集する。keymapはkeyball44/my_keymap/以下を使う。
 
-5. ビルド&flash
+2. ビルド&flash
 $ qmk flash -kb keyball/keyball44 -km my_keymap
 
 # やったことメモ
 
-1. トラックボール加速機能実装
-   以下を参考にした。
+1. トラックボール加速機能実装  
+   以下を参考にした。  
    https://x.com/mass_0X00/status/1824373363604853180
-2. マウスキーを押すまでAutoMouseLayerに留まる
-   以下を参考にした。
-   https://github.com/negokaz/keyball/pull/2
-3. PERMISSIVE_HOLDを有効にした
+2. マウスキーを押すまでAutoMouseLayerに留まる  
+   以下を参考にした。  
+   https://github.com/negokaz/keyball/pull/2  
+3. PERMISSIVE_HOLDを有効にした  
    押下時間に関係なく、押下中に他キー押下でHOLD判定になる。
+4. QUICK_TAP設定をオフにした。  
+   QUICK_TAP_TERMを0にすることでQUICK_TAP(連打)した際でもHOLDされるようにした。  
+   https://golden-lucky.hatenablog.com/entry/2021/03/06/182958
 
 # 参考
 

--- a/qmk_firmware/keyboards/keyball/keyball44/keymaps/my_keymap/config.h
+++ b/qmk_firmware/keyboards/keyball/keyball44/keymaps/my_keymap/config.h
@@ -40,3 +40,4 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define AUTO_MOUSE_LAYER_KEEP_TIME 30000
 
 #define PERMISSIVE_HOLD
+#define QUICK_TAP_TERM 0


### PR DESCRIPTION
QUICK_TAP_TERMを0にすることでQUICK_TAP(連打)した際でもHOLDされるようにした。  
これでLayerキーを誤ってQUICK_TAPしてもLayer移動が有効になるはず。  
https://golden-lucky.hatenablog.com/entry/2021/03/06/182958